### PR TITLE
enable silent refresh token

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -11,7 +11,8 @@
         {"glob":"**/*.js", "input":"../node_modules/oidc-client/dist/","output":"./"},
         { "glob": "**/*", "input": "./assets/", "output": "./assets/" },
         { "glob": "favicon.ico", "input": "./", "output": "./" },
-        { "glob": "auth.html", "input": "./", "output": "./" }
+        { "glob": "auth.html", "input": "./", "output": "./" },
+        { "glob": "silent-renew.html", "input": "./", "output": "./" }
         
       ],
       "index": "index.html",

--- a/src/app/protected/protected.component.html
+++ b/src/app/protected/protected.component.html
@@ -3,5 +3,9 @@
 </div>
 <br>
 <div>
+  <button (click)="getSecureValue()">Get Secure Value</button>
+  {{values}}
+</div>
+<div>
   To go back click <a (click)="goback()">here</a>.
 </div>

--- a/src/app/protected/protected.component.ts
+++ b/src/app/protected/protected.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
+import { AuthService } from '../shared/services/auth.service';
 
 @Component({
   selector: 'app-protected',
@@ -8,11 +9,21 @@ import { Location } from '@angular/common';
 })
 export class ProtectedComponent implements OnInit {
 
-  constructor(private location:Location) { }
+  baseUrl: string = 'http://localhost:61138';
+  values: string;
+  constructor(private location: Location, private authService: AuthService) { }
 
   ngOnInit() {
   }
-  goback(){
+
+  getSecureValue() {
+    this.authService.AuthGet(this.baseUrl + '/values').subscribe((response => {
+      this.values = response.json();
+    }));
+
+  }
+
+  goback() {
     this.location.back();
   }
 

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -13,13 +13,15 @@ const settings: any = {
   response_type: 'id_token token',
   scope: 'openid email roles',
 
-  silent_redirect_uri: 'http://localhost:4200',
+  silent_redirect_uri: window.location.protocol + "//" + window.location.host + "/silent-renew.html",
   automaticSilentRenew: true,
+  accessTokenExpiringNotificationTime: 4,
   // silentRequestTimeout:10000,
 
   filterProtocolClaims: true,
   loadUserInfo: true
 };
+
 
 @Injectable()
 export class AuthService {
@@ -32,6 +34,7 @@ export class AuthService {
 
 
   constructor(private http: Http) {
+
     this.mgr.getUser()
       .then((user) => {
         if (user) {
@@ -46,6 +49,13 @@ export class AuthService {
       .catch((err) => {
         this.loggedIn = false;
       });
+
+    this.mgr.events.addUserLoaded((user) => {
+      this.currentUser = user;
+      console.log("authService addUserLoaded", user);
+
+    });
+
     this.mgr.events.addUserUnloaded((e) => {
       if (!environment.production) {
         console.log('user unloaded');
@@ -63,6 +73,7 @@ export class AuthService {
 
   getUser() {
     this.mgr.getUser().then((user) => {
+      this.currentUser = user;
       console.log('got user', user);
       this.userLoadededEvent.emit(user);
     }).catch(function (err) {

--- a/src/silent-renew.html
+++ b/src/silent-renew.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <h1 id="waiting">Waiting...</h1>
+    <div id="error"></div>
+    <script src="assets/oidc-client.min.js"></script>
+    <script>
+         new UserManager().signinSilentCallback();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit enable silent refresh token : 

-  silent-renew.html added
-  settings updated : 
         ```silent_redirect_uri:'http://localhost:4200/silent-renew.html',
           accessTokenExpiringNotificationTime: 4,```
- event userLoaded added (to refresh currentuser with the new access_token) : 

```
    this.mgr.events.addUserLoaded((user) => {
      this.currentUser = user;
    });
```

- Don't forget to update IdentityServer RedirectUris : 

  
                 ```RedirectUris = new List<string>
                {
                    "http://localhost:4200/auth.html",
                    "http://localhost:4200/silent-renew.html"
                },
                AccessTokenLifetime = 60 ```





 