### PR TITLE
Update Auth.html to prefix items with 'Oidc.'

### DIFF
--- a/src/auth.html
+++ b/src/auth.html
@@ -9,8 +9,8 @@
     <div id="error"></div>
     <script src="oidc-client.min.js"></script>
     <script>
-        Log.logger = console;
-        new UserManager().signinRedirectCallback().then(function (user) {
+        Oidc.Log.logger = console;
+        new Oidc.UserManager().signinRedirectCallback().then(function (user) {
             if (user == null) {
                 document.getElementById("waiting").style.display = "none";
                 document.getElementById("error").innerText = "No sign-in request pending.";


### PR DESCRIPTION
I was getting errors in the console on Auth.html until I prefixed Log and UserManager with '.Oidc.' I am not sure if this is due to the oidc-client version I am using (v1.3.0) or if the issue is in the code on my end. I noticed in these [docs](https://github.com/IdentityModel/oidc-client-js/wiki#logging) they are prefixing with '.Oidc' so I tried it and the errors went away.