### PR TITLE
Fixed references to global Oidc.UserManager

### DIFF
--- a/src/scripts/auth.js
+++ b/src/scripts/auth.js
@@ -1,3 +1,6 @@
+var Oidc = window.Oidc,
+    UserManager = Oidc.UserManager;
+
 if((Oidc && Oidc.Log && Oidc.Log.logger)){
     Oidc.Log.logger = console;
 }

--- a/src/scripts/silent-renew.js
+++ b/src/scripts/silent-renew.js
@@ -1,3 +1,6 @@
+var Oidc = window.Oidc,
+    UserManager = Oidc.UserManager;
+    
 if ((Oidc && Oidc.Log && Oidc.Log.logger)) {
     Oidc.Log.logger = console;
 }


### PR DESCRIPTION
UserManager was always going to return undefined in auth.js and silent-renew.js.